### PR TITLE
Add unit tests for backend utilities

### DIFF
--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+const AuthService = require('../backend/services/authService');
+
+describe('AuthService token methods', () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = 'testsecret';
+  });
+
+  it('generateToken and verifyToken round trip', () => {
+    const token = AuthService.generateToken({ _id:'1', email:'a@test.com', userType:'admin' });
+    const decoded = AuthService.verifyToken(token);
+    expect(decoded.email).toBe('a@test.com');
+    expect(decoded.userType).toBe('admin');
+  });
+
+  it('verifyToken returns null on invalid token', () => {
+    const token = AuthService.generateToken({ _id:'1', email:'a@test.com', userType:'admin' });
+    expect(AuthService.verifyToken(token + 'bad')).toBeNull();
+  });
+});

--- a/tests/errorHandler.test.js
+++ b/tests/errorHandler.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../backend/utils/logger', () => ({
+  default: { error: vi.fn() },
+  error: vi.fn(),
+}));
+
+const responseFormatter = require('../backend/utils/responseFormatter');
+vi.spyOn(responseFormatter, 'validationError');
+vi.spyOn(responseFormatter, 'authError');
+vi.spyOn(responseFormatter, 'forbidden');
+vi.spyOn(responseFormatter, 'notFound');
+vi.spyOn(responseFormatter, 'conflict');
+vi.spyOn(responseFormatter, 'error');
+vi.spyOn(responseFormatter, 'serverError');
+
+const errorHandler = require('../backend/middlewares/errorHandler');
+const {
+  ValidationError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ConflictError,
+  AppError
+} = require('../backend/utils/errorTypes');
+
+function run(err) {
+  const req = { path:'/p', method:'GET' };
+  const res = {};
+  const next = vi.fn();
+  errorHandler(err, req, res, next);
+}
+
+describe('errorHandler middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handles ValidationError', () => {
+    run(new ValidationError('bad',{a:'b'}));
+    expect(responseFormatter.validationError).toHaveBeenCalledWith({}, {a:'b'});
+  });
+
+  it('handles AuthenticationError', () => {
+    run(new AuthenticationError('no'));
+    expect(responseFormatter.authError).toHaveBeenCalledWith({}, 'no');
+  });
+
+  it('handles AuthorizationError', () => {
+    run(new AuthorizationError('no'));
+    expect(responseFormatter.forbidden).toHaveBeenCalledWith({}, 'no');
+  });
+
+  it('handles NotFoundError', () => {
+    run(new NotFoundError('no'));
+    expect(responseFormatter.notFound).toHaveBeenCalledWith({}, 'no');
+  });
+
+  it('handles ConflictError', () => {
+    run(new ConflictError('no'));
+    expect(responseFormatter.conflict).toHaveBeenCalledWith({}, 'no');
+  });
+
+  it('handles AppError fallback', () => {
+    run(new AppError('oops',418));
+    expect(responseFormatter.error).toHaveBeenCalledWith({}, 'oops', 418);
+  });
+
+  it('handles mongoose ValidationError name', () => {
+    run({ name:'ValidationError', errors:{ field:{ message:'e' } } });
+    expect(responseFormatter.validationError).toHaveBeenCalledWith({}, { field:'e' });
+  });
+
+  it('handles duplicate key error code 11000', () => {
+    run({ code:11000 });
+    expect(responseFormatter.conflict).toHaveBeenCalled();
+  });
+
+  it('handles JWT errors', () => {
+    run({ name:'JsonWebTokenError' });
+    expect(responseFormatter.authError).toHaveBeenCalledWith({}, 'Invalid token');
+  });
+
+  it('handles TokenExpiredError', () => {
+    run({ name:'TokenExpiredError' });
+    expect(responseFormatter.authError).toHaveBeenCalledWith({}, 'Token expired');
+  });
+
+  it('handles generic error', () => {
+    run(new Error('x'));
+    expect(responseFormatter.serverError).toHaveBeenCalled();
+  });
+});

--- a/tests/errorTypes.test.js
+++ b/tests/errorTypes.test.js
@@ -1,0 +1,67 @@
+const {
+  AppError,
+  ValidationError,
+  AuthenticationError,
+  AuthorizationError,
+  NotFoundError,
+  ConflictError,
+  RateLimitError,
+  ServerError,
+  ExternalServiceError
+} = require('../backend/utils/errorTypes');
+
+describe('Error Types', () => {
+  it('should set default properties in AppError', () => {
+    const err = new AppError('msg', 418);
+    expect(err.message).toBe('msg');
+    expect(err.statusCode).toBe(418);
+    expect(err.status).toBe('fail');
+    expect(err.isOperational).toBe(true);
+  });
+
+  it('ValidationError should inherit from AppError with defaults', () => {
+    const err = new ValidationError();
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(400);
+    expect(err.message).toBe('Validation error');
+    expect(err.errors).toEqual({});
+  });
+
+  it('AuthenticationError should set status 401', () => {
+    const err = new AuthenticationError();
+    expect(err.statusCode).toBe(401);
+    expect(err.message).toBe('Authentication error');
+  });
+
+  it('AuthorizationError should set status 403', () => {
+    const err = new AuthorizationError('nope');
+    expect(err.statusCode).toBe(403);
+    expect(err.message).toBe('nope');
+  });
+
+  it('NotFoundError should default 404', () => {
+    const err = new NotFoundError();
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('ConflictError should default 409', () => {
+    const err = new ConflictError();
+    expect(err.statusCode).toBe(409);
+  });
+
+  it('RateLimitError should default 429', () => {
+    const err = new RateLimitError();
+    expect(err.statusCode).toBe(429);
+  });
+
+  it('ServerError should default 500', () => {
+    const err = new ServerError();
+    expect(err.statusCode).toBe(500);
+  });
+
+  it('ExternalServiceError should capture service name', () => {
+    const err = new ExternalServiceError(undefined, 'zoom');
+    expect(err.service).toBe('zoom');
+    expect(err.statusCode).toBe(502);
+  });
+});

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const logDir = path.join(__dirname, '../backend/logs');
+
+const logger = require('../backend/utils/logger');
+
+describe('logger utility', () => {
+  it('creates logs directory', () => {
+    expect(fs.existsSync(logDir)).toBe(true);
+  });
+
+  it('requestLogger logs based on status code', () => {
+    const req = { method:'GET', url:'/x', headers:{} };
+    const res = { statusCode:200, on(event, cb){ if(event==='finish') this._cb=cb; }, end(){ this._cb(); }};
+    const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
+    logger.requestLogger(req, res, () => {});
+    res.on('finish', ()=>{}); // Should not call debug until finish
+    res._cb();
+    expect(debugSpy).toHaveBeenCalled();
+    debugSpy.mockRestore();
+  });
+
+  it('errorLogger logs error info', () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const err = new Error('oops');
+    const req = { method:'POST', url:'/x', body:{} };
+    logger.errorLogger(err, req, {}, () => {});
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/tests/responseFormatter.test.js
+++ b/tests/responseFormatter.test.js
@@ -1,0 +1,57 @@
+const responseFormatter = require('../backend/utils/responseFormatter');
+
+function createMockRes() {
+  return {
+    statusCode: null,
+    jsonPayload: null,
+    status(code) { this.statusCode = code; return this; },
+    json(payload) { this.jsonPayload = payload; return this; },
+    endCalled: false,
+    end() { this.endCalled = true; }
+  };
+}
+
+describe('responseFormatter', () => {
+  it('success should return formatted success object', () => {
+    const res = createMockRes();
+    responseFormatter.success(res, { a: 1 }, 'ok', 201);
+    expect(res.statusCode).toBe(201);
+    expect(res.jsonPayload).toEqual({ success: true, message: 'ok', data: { a: 1 } });
+  });
+
+  it('error should return formatted error object', () => {
+    const res = createMockRes();
+    responseFormatter.error(res, 'bad', 400, {f:'e'});
+    expect(res.statusCode).toBe(400);
+    expect(res.jsonPayload).toEqual({ success: false, message: 'bad', errors: {f:'e'} });
+  });
+
+  it('validationError should call error with 400', () => {
+    const res = createMockRes();
+    responseFormatter.validationError(res, {f:'e'});
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('paginated should include pagination info', () => {
+    const res = createMockRes();
+    responseFormatter.paginated(res, [1,2], 2, 5, 12);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonPayload.pagination).toEqual({
+      page:2, limit:5, total:12, totalPages:3,
+      hasNextPage:true, hasPrevPage:true
+    });
+  });
+
+  it('created should use success with 201', () => {
+    const res = createMockRes();
+    responseFormatter.created(res, {id:1});
+    expect(res.statusCode).toBe(201);
+  });
+
+  it('noContent should send 204 with no body', () => {
+    const res = createMockRes();
+    responseFormatter.noContent(res);
+    expect(res.statusCode).toBe(204);
+    expect(res.endCalled).toBe(true);
+  });
+});

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('express-validator', () => {
+  return {
+    validationResult: vi.fn(),
+    body: () => 'body',
+    param: () => 'param',
+    query: () => 'query'
+  };
+});
+
+const { ValidationError } = require('../backend/utils/errorTypes');
+const { validate } = require('../backend/utils/validators');
+const { validationResult } = require('express-validator');
+
+describe('validate middleware', () => {
+  it('calls next when no errors', () => {
+    validationResult.mockReturnValue({ isEmpty: () => true });
+    const next = vi.fn();
+    validate({}, {}, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('throws ValidationError with formatted errors', () => {
+    const array = () => [
+      { param: 'email', msg: 'Invalid email' },
+      { param: 'password', msg: 'too short' }
+    ];
+    validationResult.mockReturnValue({ isEmpty: () => false, array });
+    expect(() => validate({}, {}, () => {})).toThrow(ValidationError);
+    try {
+      validate({}, {}, () => {});
+    } catch (e) {
+      expect(e.errors).toEqual({ email: 'Invalid email', password: 'too short' });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- create test suite covering utility modules and middleware
- add tests for error types, response formatter, validators, logger, error handler and auth token methods

## Testing
- `npm test` *(fails: `vitest: not found`)*