### PR TITLE
Add runtime mocks for external integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ MentorConnect is a web platform that connects prospective candidates with anonym
    ```bash
    cp env-example.txt .env
    ```
-3. Edit `.env` with your own credentials for MongoDB, Stripe, SendGrid, Zoom and other keys. These variables are used by both the backend and frontend services.
+3. Edit `.env` with your own credentials for MongoDB, Stripe, SendGrid, Zoom and other keys. These variables are used by both the backend and frontend services. Set `MOCK_INTEGRATIONS=true` if you want to run the app without contacting the real external services.
 4. **Option A: Docker Compose (recommended)**
    1. Ensure Docker is running.
    2. Start the stack:

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -4,6 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const handlebars = require('handlebars');
 const logger = require('../utils/logger');
+if (process.env.MOCK_INTEGRATIONS === "true") {
+  module.exports = require("./mocks/emailService");
+  return;
+}
+
 
 class EmailService {
   constructor() {

--- a/backend/services/mocks/emailService.js
+++ b/backend/services/mocks/emailService.js
@@ -1,0 +1,41 @@
+const logger = require('../../utils/logger');
+
+class MockEmailService {
+  async loadTemplate(name) {
+    logger.debug('Mock loadTemplate', name);
+    return () => `Mock template ${name}`;
+  }
+
+  async sendEmail(to, subject, templateName, vars) {
+    logger.debug('Mock sendEmail', { to, subject, templateName, vars });
+    return true;
+  }
+
+  extractDomain(email) {
+    return email ? email.split('@')[1] : null;
+  }
+
+  validateDomainMatch(a, b) {
+    return this.extractDomain(a) === this.extractDomain(b);
+  }
+
+  parseReferralEmail(data) {
+    logger.debug('Mock parseReferralEmail', data);
+    return {
+      senderEmail: data.from,
+      recipientEmail: data.to,
+      ccEmails: [],
+      referralEmailId: 'ref_mock',
+      timestamp: new Date(),
+      isPlatformCCd: true,
+      domainsMatch: true
+    };
+  }
+
+  async sendSessionConfirmation() { return true; }
+  async sendPaymentConfirmation() { return true; }
+  async sendPayoutNotification() { return true; }
+  convertHtmlToText(html) { return html; }
+}
+
+module.exports = new MockEmailService();

--- a/backend/services/mocks/stripeService.js
+++ b/backend/services/mocks/stripeService.js
@@ -1,0 +1,60 @@
+const logger = require('../../utils/logger');
+
+function mockResponse(data = {}) {
+  return { id: `${data.type || 'mock'}_${Date.now()}`, ...data };
+}
+
+exports.createCheckoutSession = async (opts) => {
+  logger.debug('Mock Stripe createCheckoutSession', opts);
+  return mockResponse({ type: 'cs', url: 'https://stripe.mock/checkout' });
+};
+
+exports.createConnectAccount = async (professionalId, email) => {
+  logger.debug('Mock Stripe createConnectAccount', { professionalId, email });
+  return { accountId: 'acct_mock', accountLink: 'https://stripe.mock/connect' };
+};
+
+exports.getConnectAccount = async (accountId) => {
+  logger.debug('Mock Stripe getConnectAccount', { accountId });
+  return mockResponse({ type: 'acct' });
+};
+
+exports.createRefund = async (paymentIntentId, reason = 'requested_by_customer') => {
+  logger.debug('Mock Stripe createRefund', { paymentIntentId, reason });
+  return mockResponse({ type: 'refund', reason });
+};
+
+exports.createDirectCharge = async (opts) => {
+  logger.debug('Mock Stripe createDirectCharge', opts);
+  return mockResponse({ type: 'pi' });
+};
+
+exports.createCustomer = async (email, name) => {
+  logger.debug('Mock Stripe createCustomer', { email, name });
+  return mockResponse({ type: 'cus', email, name });
+};
+
+exports.createPaymentMethod = async (customerId, data) => {
+  logger.debug('Mock Stripe createPaymentMethod', { customerId, data });
+  return mockResponse({ type: 'pm' });
+};
+
+exports.confirmPaymentIntent = async (paymentIntentId) => {
+  logger.debug('Mock Stripe confirmPaymentIntent', { paymentIntentId });
+  return mockResponse({ type: 'pi_confirmed' });
+};
+
+exports.handleWebhookEvent = (payload, signature) => {
+  logger.debug('Mock Stripe handleWebhookEvent', { payload, signature });
+  return { id: 'evt_mock', type: 'mock.event', data: {} };
+};
+
+exports.getPaymentIntent = async (paymentIntentId) => {
+  logger.debug('Mock Stripe getPaymentIntent', { paymentIntentId });
+  return mockResponse({ type: 'pi' });
+};
+
+exports.listPayouts = async (accountId, options = {}) => {
+  logger.debug('Mock Stripe listPayouts', { accountId, options });
+  return [];
+};

--- a/backend/services/mocks/zoomService.js
+++ b/backend/services/mocks/zoomService.js
@@ -1,0 +1,35 @@
+const logger = require('../../utils/logger');
+
+class MockZoomService {
+  async getZoomToken() {
+    logger.debug('Mock getZoomToken');
+    return 'mock_zoom_token';
+  }
+
+  async createMeeting(session, professional, user) {
+    logger.debug('Mock createMeeting', { session, professional, user });
+    return {
+      meetingId: 'zoom_mock_meeting',
+      meetingUrl: 'https://zoom.mock/join',
+      password: 'mockpass',
+      startUrl: 'https://zoom.mock/start'
+    };
+  }
+
+  async verifyMeeting(meetingId) {
+    logger.debug('Mock verifyMeeting', { meetingId });
+    return {
+      verified: true,
+      duration: 30,
+      participantCount: 2,
+      startTime: new Date().toISOString(),
+      endTime: new Date(Date.now() + 1800000).toISOString()
+    };
+  }
+
+  verifyWebhookSignature() { return true; }
+  generateMeetingPassword() { return 'mockpass'; }
+  async handleMeetingEnded() { return { verified: true }; }
+}
+
+module.exports = new MockZoomService();

--- a/backend/services/stripeService.js
+++ b/backend/services/stripeService.js
@@ -3,6 +3,11 @@
  */
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const logger = require('../utils/logger');
+if (process.env.MOCK_INTEGRATIONS === "true") {
+  module.exports = require("./mocks/stripeService");
+  return;
+}
+
 
 /**
  * Create a checkout session for a mentoring session

--- a/backend/services/zoomService.js
+++ b/backend/services/zoomService.js
@@ -2,6 +2,11 @@ const axios = require('axios');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
 const logger = require('../utils/logger');
+if (process.env.MOCK_INTEGRATIONS === "true") {
+  module.exports = require("./mocks/zoomService");
+  return;
+}
+
 
 class ZoomService {
   constructor() {

--- a/env-example.txt
+++ b/env-example.txt
@@ -2,7 +2,8 @@
 NODE_ENV=development
 PORT=5000
 FRONTEND_URL=http://localhost:3000
-
+# Set to true to disable real external integrations
+MOCK_INTEGRATIONS=false
 # MongoDB
 MONGO_USERNAME=admin
 MONGO_PASSWORD=password


### PR DESCRIPTION
## Summary
- create Stripe, SendGrid and Zoom mock implementations
- switch to mocks when `MOCK_INTEGRATIONS=true`
- document the new flag in README and env example

## Testing
- `npm test`