### PR TITLE
Implement better express error handling

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -10,6 +10,8 @@ const logger = require('./utils/logger');
 const cronJobs = require('./cron');
 const metrics = require('./utils/metrics');
 const { archiveLogs } = require('./utils/compliance');
+const errorHandler = require('./middlewares/errorHandler');
+const { NotFoundError } = require('./utils/errorTypes');
 
 // Initialize Express app
 const app = express();
@@ -35,6 +37,14 @@ if (process.env.NODE_ENV === 'production') {
     res.sendFile(path.resolve(__dirname, '../frontend/build', 'index.html'));
   });
 }
+
+// Handle unmatched routes
+app.all('*', (req, res, next) => {
+  next(new NotFoundError(`Route ${req.originalUrl} not found`));
+});
+
+// Error handling middleware
+app.use(errorHandler);
 
 // Set up Socket.io
 const io = socketIo(server, {

--- a/backend/config/middleware.js
+++ b/backend/config/middleware.js
@@ -5,7 +5,9 @@ const morgan = require('morgan');
 const passport = require('passport');
 const { apiLimiter } = require('../middlewares/rateLimiter');
 const { swaggerSpec, swaggerUi } = require('./swagger');
-const errorHandler = require('../middlewares/errorHandler');
+// The errorHandler middleware should be registered after routes
+// so it is imported in app.js instead of here.
+// const errorHandler = require('../middlewares/errorHandler');
 const logger = require('../utils/logger');
 
 /**
@@ -48,11 +50,10 @@ const configureMiddleware = (app) => {
   
   // Swagger API docs
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-  
 
-  
-  // Error handling middleware
-  app.use(errorHandler);
-};
+  // Error handling middleware is registered in app.js
+  // after all routes so that errors from routes are
+  // properly handled.
+}; 
 
 module.exports = configureMiddleware;


### PR DESCRIPTION
## Notes
- no network access prevented installing eslint dependencies

## Summary
- remove error handler from general middleware configuration
- register 404 handler and error middleware at the end of `app.js`

## Testing
- `npm test`
