### PR TITLE
Add payment hold and release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MentorConnect is a web platform that connects prospective candidates with anonym
 
 - **Virtual Networking Sessions**: Connect with industry professionals through Zoom meetings
 - **Anonymized Professionals**: Professionals can maintain anonymity while sharing insights
-- **Secure Payments**: Payments are processed only after verified sessions via Zoom
+- **Secure Payments**: Payments are held on Stripe and released to professionals only after the session has been verified
 - **Referral System**: Professionals can refer candidates to colleagues and earn rewards
 - **Email Integration**: Automatically tracks and verifies referral emails
 - **GDPR Compliance**: Users can delete their data via `/api/users/me/delete`

--- a/backend/models/session.js
+++ b/backend/models/session.js
@@ -27,7 +27,7 @@ const sessionSchema = new Schema({
   },
   paymentStatus: {
     type: String,
-    enum: ['pending', 'paid', 'refunded', 'released'],
+    enum: ['pending', 'authorized', 'paid', 'refunded', 'released'],
     default: 'pending'
   },
   paymentId: {

--- a/backend/webhooks/stripeWebhook.js
+++ b/backend/webhooks/stripeWebhook.js
@@ -46,8 +46,10 @@ const handlePaymentIntentSucceeded = async (paymentIntent) => {
       return null;
     }
     
-    session.paymentStatus = 'paid';
-    await session.save();
+    if (session.paymentStatus !== 'released') {
+      session.paymentStatus = 'paid';
+      await session.save();
+    }
     
     // Create payment record
     const payment = new Payment({

--- a/tests/paymentService.test.js
+++ b/tests/paymentService.test.js
@@ -1,11 +1,61 @@
 const { describe, it, expect, vi } = require('./test-helpers');
 
-vi.mock('../backend/models/session', () => ({}));
-vi.mock('../backend/models/user', () => ({}));
-vi.mock('../backend/models/professionalProfile', () => ({}));
+const mockSession = {
+  _id: 'sess1',
+  professional: {
+    _id: 'pro1',
+    stripeConnectedAccountId: 'acct_1',
+    anonymizedProfile: { displayName: 'Pro One' },
+    user: 'proUser1',
+    statistics: { completedSessions: 0, totalEarnings: 0 }
+  },
+  user: 'user1',
+  price: 100,
+  zoomMeetingVerified: true,
+  status: 'completed',
+  save: vi.fn()
+};
+vi.mock('../backend/models/session', () => ({
+  findById: vi.fn(() => ({
+    populate: () => ({
+      populate: () => Promise.resolve(mockSession)
+    })
+  }))
+}));
+
+const mockUser = {
+  _id: 'user1',
+  email: 'user@test.com',
+  firstName: 'User',
+  lastName: 'Test',
+  stripeCustomerId: null,
+  save: vi.fn()
+};
+vi.mock('../backend/models/user', () => ({
+  findById: vi.fn(() => Promise.resolve(mockUser))
+}));
+vi.mock('../backend/models/professionalProfile', () => ({
+  findById: vi.fn(() => Promise.resolve({
+    _id: 'pro1',
+    statistics: { completedSessions: 0, totalEarnings: 0 },
+    save: vi.fn()
+  }))
+}));
 vi.mock('../backend/utils/logger', () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }));
 const transferSpy = vi.fn(async () => ({ id: 'tr_1' }));
-const stripeInstance = { transfers: { create: transferSpy } };
+const paymentIntentCreateSpy = vi.fn(async () => ({
+  id: 'pi_1',
+  status: 'requires_capture',
+  client_secret: 'sec',
+  charges: { data: [{ receipt_url: 'http://r' }] }
+}));
+const paymentIntentCaptureSpy = vi.fn(async () => ({ id: 'pi_1', status: 'succeeded' }));
+const customerCreateSpy = vi.fn(async () => ({ id: 'cus_1' }));
+const stripeInstance = {
+  transfers: { create: transferSpy },
+  paymentIntents: { create: paymentIntentCreateSpy, capture: paymentIntentCaptureSpy },
+  customers: { create: customerCreateSpy }
+};
 vi.mock('stripe', () => {
   return () => stripeInstance;
 });
@@ -50,5 +100,20 @@ describe('payment service', () => {
   it('uses idempotency key for referral payouts', async () => {
     await PaymentService.processReferralPayment('ref1');
     expect(transferSpy.mock.calls[0][1]).toEqual({ idempotencyKey: 'referral-ref1' });
+  });
+
+  it('creates payment intent with manual capture', async () => {
+    await PaymentService.processSessionPayment('sess1', 'pm_1', 'user1');
+    expect(paymentIntentCreateSpy.mock.calls[0][0].capture_method).toBe('manual');
+    expect(mockSession.paymentStatus).toBe('authorized');
+  });
+
+  it('captures intent and transfers funds on release', async () => {
+    mockSession.paymentId = 'pi_1';
+    mockSession.paymentStatus = 'authorized';
+    await PaymentService.releaseSessionPayment('sess1');
+    expect(paymentIntentCaptureSpy).toHaveBeenCalledWith('pi_1');
+    expect(transferSpy).toHaveBeenCalled();
+    expect(mockSession.paymentStatus).toBe('released');
   });
 });


### PR DESCRIPTION
## Summary
- hold session payments until verification by setting manual capture
- capture and transfer funds when releasing a session payment
- avoid overwriting released status in Stripe webhook
- document new deferred payout approach
- test payment service for manual capture and release

## Testing
- `npm test`