### PR TITLE
Fix backend install

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,7 @@
     "uuid": "^9.0.0",
     "node-cron": "^3.0.2",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.1.4",
+    "swagger-ui-express": "^4.6.3",
     "winston": "^3.10.0",
     "knex": "^2.5.1",
     "ajv": "^8.12.0",


### PR DESCRIPTION
## Summary
- adjust `swagger-ui-express` version so installation works

## Testing
- `npm --prefix backend install --offline` *(fails: cache missing)*
- `timeout 20 npm --prefix backend install` *(fails: network unavailable)*
