### PR TITLE
Fix API port for frontend services

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { getAccessToken, clearTokens, refreshTokens } from './auth';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:8000/api';
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 
 // Create axios instance
 const api = axios.create({


### PR DESCRIPTION
## Summary
- update default API_URL port from 8000 to 5000

## Testing
- `npm test`