### PR TITLE
Remove authorized payment status

### DIFF
--- a/backend/models/session.js
+++ b/backend/models/session.js
@@ -21,7 +21,7 @@ const sessionSchema = new Schema({
   },
   paymentStatus: {
     type: String,
-    enum: ['pending', 'authorized', 'paid', 'refunded', 'released'],
+    enum: ['pending', 'paid', 'refunded', 'released'],
     default: 'pending'
   },
   paymentId: {

--- a/backend/services/paymentService.js
+++ b/backend/services/paymentService.js
@@ -157,7 +157,7 @@ class PaymentService {
       
       // Update session with payment information
       session.paymentId = paymentIntent.id;
-      session.paymentStatus = 'authorized';
+      session.paymentStatus = 'paid';
       await session.save();
       
       // Send notifications

--- a/tests/paymentService.test.js
+++ b/tests/paymentService.test.js
@@ -104,12 +104,12 @@ describe('payment service', () => {
   it('creates payment intent with manual capture', async () => {
     await PaymentService.processSessionPayment('sess1', 'pm_1', 'user1');
     expect(paymentIntentCreateSpy.mock.calls[0][0].capture_method).toBe('manual');
-    expect(mockSession.paymentStatus).toBe('authorized');
+    expect(mockSession.paymentStatus).toBe('paid');
   });
 
   it('captures intent and transfers funds on release', async () => {
     mockSession.paymentId = 'pi_1';
-    mockSession.paymentStatus = 'authorized';
+    mockSession.paymentStatus = 'paid';
     await PaymentService.releaseSessionPayment('sess1');
     expect(paymentIntentCaptureSpy).toHaveBeenCalledWith('pi_1');
     expect(transferSpy).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- align `Session` paymentStatus with `Payment` model by removing the `authorized` value
- mark processed session payments as `paid`
- update tests for new status

## Testing
- `npm test`