### PR TITLE
Switch sessions to backend pagination

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -99,30 +99,22 @@ const SessionController = {
   getUserSessions: async (req, res, next) => {
     try {
       const userId = req.user.id;
+
       const { status, limit = 10, page = 1 } = req.query;
 
-      const skip = (page - 1) * limit;
-
-      // Get sessions
-      const sessions = await SessionService.getUserSessions(userId);
-
-      // Filter by status if provided
-      const filteredSessions = status
-        ? sessions.filter((session) => session.status === status)
-        : sessions;
-
-      // Paginate
-      const paginatedSessions = filteredSessions.slice(
-        skip,
-        skip + parseInt(limit),
+      const { sessions, total } = await SessionService.getUserSessions(
+        userId,
+        status,
+        parseInt(limit),
+        parseInt(page),
       );
 
       return responseFormatter.paginated(
         res,
-        paginatedSessions,
+        sessions,
         parseInt(page),
         parseInt(limit),
-        filteredSessions.length,
+        total,
         "Sessions retrieved successfully",
       );
     } catch (error) {
@@ -147,30 +139,19 @@ const SessionController = {
         throw new ValidationError("You do not have a professional profile");
       }
 
-      const skip = (page - 1) * limit;
-
-      // Get sessions
-      const sessions = await SessionService.getProfessionalSessions(
+      const { sessions, total } = await SessionService.getProfessionalSessions(
         professionalProfile._id,
-      );
-
-      // Filter by status if provided
-      const filteredSessions = status
-        ? sessions.filter((session) => session.status === status)
-        : sessions;
-
-      // Paginate
-      const paginatedSessions = filteredSessions.slice(
-        skip,
-        skip + parseInt(limit),
+        status,
+        parseInt(limit),
+        parseInt(page),
       );
 
       return responseFormatter.paginated(
         res,
-        paginatedSessions,
+        sessions,
         parseInt(page),
         parseInt(limit),
-        filteredSessions.length,
+        total,
         "Sessions retrieved successfully",
       );
     } catch (error) {

--- a/backend/services/sessionService.js
+++ b/backend/services/sessionService.js
@@ -164,26 +164,50 @@ class SessionService {
     }
   }
 
-  // Find sessions for a specific user
-  async getUserSessions(userId) {
+  // Find sessions for a specific user with optional pagination
+  async getUserSessions(userId, status = null, limit = 10, page = 1) {
     try {
-      return await Session.find({ user: userId })
-        .populate("professional")
-        .sort({ startTime: -1 })
-        .exec();
+      const filter = { user: userId };
+      if (status) filter.status = status;
+
+      const skip = (page - 1) * limit;
+
+      const [sessions, total] = await Promise.all([
+        Session.find(filter)
+          .populate("professional")
+          .sort({ startTime: -1 })
+          .skip(skip)
+          .limit(parseInt(limit))
+          .exec(),
+        Session.countDocuments(filter)
+      ]);
+
+      return { sessions, total };
     } catch (error) {
       logger.error(`Failed to get user sessions: ${error.message}`);
       throw new Error(`Failed to get user sessions: ${error.message}`);
     }
   }
 
-  // Find sessions for a specific professional
-  async getProfessionalSessions(professionalId) {
+  // Find sessions for a specific professional with optional pagination
+  async getProfessionalSessions(professionalId, status = null, limit = 10, page = 1) {
     try {
-      return await Session.find({ professional: professionalId })
-        .populate("user", "-password")
-        .sort({ startTime: -1 })
-        .exec();
+      const filter = { professional: professionalId };
+      if (status) filter.status = status;
+
+      const skip = (page - 1) * limit;
+
+      const [sessions, total] = await Promise.all([
+        Session.find(filter)
+          .populate("user", "-password")
+          .sort({ startTime: -1 })
+          .skip(skip)
+          .limit(parseInt(limit))
+          .exec(),
+        Session.countDocuments(filter)
+      ]);
+
+      return { sessions, total };
     } catch (error) {
       logger.error(`Failed to get professional sessions: ${error.message}`);
       throw new Error(`Failed to get professional sessions: ${error.message}`);


### PR DESCRIPTION
## Summary
- paginate user and professional session lists directly in MongoDB
- fix missing query parameters after refactor

## Testing
- `npm test`
- `npm run lint` *(fails: A config object is using the "extends" key)*