### PR TITLE
Fix tests requiring env vars

### DIFF
--- a/tests/googleAuth.test.js
+++ b/tests/googleAuth.test.js
@@ -21,6 +21,7 @@ vi.mock('bcryptjs', () => ({ genSalt: vi.fn(), hash: vi.fn(), compare: vi.fn() }
 vi.mock('crypto', () => ({ randomBytes: () => Buffer.from('rand') }));
 vi.mock('jsonwebtoken', () => ({ sign: () => 'token' }));
 
+process.env.JWT_SECRET = 'secret';
 const AuthService = require('../backend/services/authService');
 
 describe('AuthService.googleLogin', () => {

--- a/tests/paymentService.test.js
+++ b/tests/paymentService.test.js
@@ -91,6 +91,7 @@ vi.mock('../backend/services/emailService', () => ({
   sendPayoutNotification: vi.fn()
 }));
 
+process.env.STRIPE_SECRET_KEY = 'test';
 const PaymentService = require('../backend/services/paymentService');
 
 process.env.REFERRAL_REWARD_AMOUNT = '50';


### PR DESCRIPTION
## Summary
- initialize STRIPE_SECRET_KEY before loading payment service
- set JWT_SECRET before loading auth service

## Testing
- `npm test`