### PR TITLE
Switch tests to Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/*.test.js'],
+  clearMocks: true,
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  transform: {},
+  coverageProvider: 'v8'
+};

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "zustand": "^4.3.8"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
     "@types/react": "^18.2.12",
@@ -41,9 +41,10 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "jest": "^29.7.0",
+    "mongoose": "^7.6.0",
     "postcss": "^8.4.24",
     "prettier": "^2.8.8",
-    "mongoose": "^7.6.0",
     "tailwindcss": "^3.3.2",
     "typescript": "^5.1.3",
     "vite": "^4.3.9",
@@ -53,7 +54,7 @@
     "start": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "test": "node --test",
+    "test": "jest --coverage",
     "lint": "eslint frontend/src --ext .js,.jsx,.ts,.tsx --config .eslintrc.cjs",
     "lint:fix": "eslint frontend/src --ext .js,.jsx,.ts,.tsx --config .eslintrc.cjs --fix",
     "format": "prettier --write \"frontend/src/**/*.{js,jsx,ts,tsx,css,md}\""

--- a/tests/authEndpoints.test.js
+++ b/tests/authEndpoints.test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, expect, vi, jest, render, screen } = require('./test-helpers');
+const { describe, it, before, after, expect, vi, render, screen } = require('./test-helpers');
 const path = require('path');
 
 process.env.JWT_SECRET = 'testsecret';

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -1,110 +1,32 @@
-const { describe, it, before, beforeEach } = require('node:test');
-const assert = require('assert/strict');
-const Module = require('module');
-const { jest } = require('@jest/globals');
+const { describe, it, beforeAll, afterAll, beforeEach, afterEach, expect, jest: Jest } = require('@jest/globals');
 const { render, screen } = require('@testing-library/react');
 
-const beforeAll = before;
-
-function expect(received) {
-  return {
-    toBe: (expected) => assert.strictEqual(received, expected),
-    toEqual: (expected) => assert.deepStrictEqual(received, expected),
-    toBeNull: () => assert.strictEqual(received, null),
-    toBeInstanceOf: (cls) => assert.ok(received instanceof cls),
-    toThrow: (err) => assert.throws(received, err),
-    toHaveBeenCalled: () => {
-      assert.ok(received.mock && received.mock.calls.length > 0, 'Expected function to have been called');
-    },
-    toHaveBeenCalledWith: (...args) => {
-      assert.ok(received.mock && received.mock.calls.some(call => {
-        try { assert.deepStrictEqual(call, args); return true; }
-        catch { return false; }
-      }), 'Expected function to have been called with provided arguments');
-    }
-  };
-}
-
-const spies = new Set();
-const mockModules = {};
-
-function fn(impl = () => {}) {
-  let implementation = impl;
-  const spy = function(...args) {
-    spy.mock.calls.push(args);
-    return implementation.apply(this, args);
-  };
-  spy.mock = { calls: [] };
-  spy.mockImplementation = (newImpl) => { implementation = newImpl; return spy; };
-  spy.mockReturnValue = (val) => { implementation = () => val; return spy; };
-  spy.mockRestore = () => { implementation = impl; spy.mock.calls = []; };
-  spies.add(spy);
-  return spy;
-}
-
-function spyOn(obj, method) {
-  const original = obj[method];
-  const spy = fn();
-  const wrapper = function(...args) {
-    const result = spy.apply(this, args);
-    if (wrapper.impl) return wrapper.impl.apply(this, args);
-    return result;
-  };
-  wrapper.mock = spy.mock;
-  wrapper.mockImplementation = (impl) => { wrapper.impl = impl; return wrapper; };
-  wrapper.mockRestore = () => { obj[method] = original; spies.delete(wrapper); };
-  obj[method] = wrapper;
-  spies.add(wrapper);
-  return wrapper;
-}
-
-function mock(modulePath, factory) {
-  let resolved;
-  try {
-    resolved = Module._resolveFilename(modulePath, module.parent);
-  } catch {
-    resolved = undefined;
-  }
-  const mod = factory();
-  mockModules[modulePath] = mod;
-  if (resolved && resolved !== modulePath) {
-    mockModules[resolved] = mod;
-  }
-  return mod;
-}
-
-function clearAllMocks() {
-  spies.forEach(spy => { spy.mock.calls = []; });
-}
-
-const vi = { fn, spyOn, mock, clearAllMocks };
-
-// Intercept module loading to return mocks if provided
-const originalLoad = Module._load;
-Module._load = function(request, parent, isMain) {
-  let resolved;
-  try {
-    resolved = Module._resolveFilename(request, parent);
-  } catch {
-    resolved = request;
-  }
-  if (Object.prototype.hasOwnProperty.call(mockModules, resolved)) {
-    return mockModules[resolved];
-  }
-  if (Object.prototype.hasOwnProperty.call(mockModules, request)) {
-    return mockModules[request];
-  }
-  return originalLoad(request, parent, isMain);
+const vi = {
+  fn: Jest.fn,
+  spyOn: (obj, method) => {
+    const spy = Jest.spyOn(obj, method);
+    spy.mockImplementation(() => undefined);
+    return spy;
+  },
+  mock: (moduleName, factory) => Jest.mock(moduleName, factory, { virtual: true }),
+  clearAllMocks: Jest.clearAllMocks
 };
+
+// Provide aliases for compatibility with existing tests
+const before = beforeAll;
+const after = afterAll;
 
 module.exports = {
   describe,
   it,
   expect,
   vi,
-  beforeEach,
-  beforeAll,
-  jest,
   render,
-  screen
+  screen,
+  before,
+  after,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach
 };


### PR DESCRIPTION
## Summary
- switch from node:test to Jest
- provide Jest config and helpers
- update test script
- adjust helper imports

## Testing
- `npm test`