### PR TITLE
Centralize ports in root env file

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,13 @@ NODE_ENV=development
 PORT=5000
 # Host port for the API container
 API_PORT=8000
+# Host port for the frontend container
+FRONTEND_PORT=3000
+# Port the frontend server listens on inside its container
+FRONTEND_INTERNAL_PORT=80
+# Host ports for the nginx proxy
+NGINX_PORT=80
+NGINX_SSL_PORT=443
 FRONTEND_URL=http://localhost:3000
 # Set to true to disable real external integrations
 MOCK_INTEGRATIONS=true

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ access to specific roles (e.g. `candidate`, `professional`, `admin`).
    When this flag is enabled, MongoDB will automatically import the JSON files under `mock-data/` the first time the stack is started.
 4. **Option A: Docker Compose (recommended)**
    1. Ensure Docker is running.
-   2. Start the stack (set `API_PORT` in `.env` if port 5000 is already in use):
+   2. Start the stack (set `API_PORT` or `FRONTEND_PORT` in `.env` if the default ports are already in use):
       ```bash
       docker compose up --build
       ```
-   3. The frontend will be available at `http://localhost:3000` and the API at `http://localhost:${API_PORT:-5000}`.
+   3. The frontend will be available at `http://localhost:${FRONTEND_PORT:-3000}` and the API at `http://localhost:${API_PORT:-5000}`.
    4. When you're done, stop the stack:
       ```bash
       docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,9 @@ services:
         - REACT_APP_STRIPE_PUBLIC_KEY=${REACT_APP_STRIPE_PUBLIC_KEY}
     restart: always
     ports:
-      - "3000:80"
+      - "${FRONTEND_PORT:-3000}:${FRONTEND_INTERNAL_PORT:-80}"
+    environment:
+      - FRONTEND_INTERNAL_PORT=${FRONTEND_INTERNAL_PORT}
     depends_on:
       - backend
     networks:
@@ -83,8 +85,8 @@ services:
   nginx:
     image: nginx:alpine
     ports:
-      - "80:80"
-      - "443:443"
+      - "${NGINX_PORT:-80}:80"
+      - "${NGINX_SSL_PORT:-443}:443"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
       - ./certbot/conf:/etc/letsencrypt

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,0 @@
-REACT_APP_API_URL=http://localhost:8000/api
-REACT_APP_STRIPE_PUBLIC_KEY=pk_test_your_stripe_public_key

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,13 +1,16 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0',
-    port: 80
-  },
-  build: {
-    outDir: 'dist'
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  return {
+    plugins: [react()],
+    server: {
+      host: '0.0.0.0',
+      port: parseInt(env.FRONTEND_INTERNAL_PORT) || 80
+    },
+    build: {
+      outDir: 'dist'
+    }
   }
 })

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^0.32.2"
   },
   "scripts": {
-    "start": "vite --port 80 --host 0.0.0.0",
+    "start": "vite --host 0.0.0.0",
     "build": "vite build",
     "serve": "vite preview",
     "test": "jest --coverage",


### PR DESCRIPTION
## Summary
- route all container ports through root `.env`
- update docker-compose to respect new env vars
- adjust Vite config and npm scripts to use env ports
- document new options in README

## Testing
- `npm test`