### PR TITLE
Fix docker frontend port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
         - REACT_APP_STRIPE_PUBLIC_KEY=${REACT_APP_STRIPE_PUBLIC_KEY}
     restart: always
     ports:
-      - "3001"
+      - "3000:3000"
     depends_on:
       - backend
     networks:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 # Change ownership
 RUN chown -R node:node /usr/src/app /usr/src/node_modules
 
-EXPOSE 80
+EXPOSE 3000
 USER node
 
 CMD ["npm", "start"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -17,7 +17,7 @@ server {
 
     # Frontend routes
     location / {
-        proxy_pass http://frontend:80/;
+        proxy_pass http://frontend:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -28,7 +28,7 @@ server {
     }
     
     location @fallback {
-        proxy_pass http://frontend:80/;
+        proxy_pass http://frontend:3000/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "dev": "vite --port 3000",
-    "start": "vite --port 80 --host 0.0.0.0",
+    "start": "vite --port 3000 --host 0.0.0.0",
     "build": "vite build",
     "serve": "vite preview",
     "test": "jest --coverage",


### PR DESCRIPTION
## Summary
- run the Vite dev server on port 3000
- expose port 3000 from the frontend container
- map docker compose to port 3000 and update nginx proxy

## Testing
- `npm test` *(fails: EmailService and authEndpoints tests)*

------
https://chatgpt.com/codex/tasks/task_e_683a354b7d248325974760a33cd0ad57