### PR TITLE
Restrict resume uploads to candidate users

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -8,7 +8,15 @@ const AuthController = {
   // Register a new user
   register: async (req, res, next) => {
     try {
-      const { email, password, firstName, lastName, userType, offerBonusAmount } = req.body;
+      const {
+        email,
+        password,
+        firstName,
+        lastName,
+        userType,
+        resume,
+        offerBonusAmount
+      } = req.body;
       
       // Validate required fields
       if (!email || !password || !firstName || !lastName) {
@@ -21,6 +29,7 @@ const AuthController = {
         firstName,
         lastName,
         userType,
+        resume,
         offerBonusAmount: offerBonusAmount || 0,
       });
       

--- a/backend/services/authService.js
+++ b/backend/services/authService.js
@@ -6,17 +6,30 @@ const EmailService = require('./emailService');
 const logger = require('../utils/logger');
 const GoogleService = require('./googleService');
 const config = require('../config');
+const { AuthorizationError } = require('../utils/errorTypes');
 
 class AuthService {
   // Register a new user
   async register(userData) {
     try {
-      const { email, password, firstName, lastName, userType, resume, offerBonusAmount } = userData;
+      const {
+        email,
+        password,
+        firstName,
+        lastName,
+        userType,
+        resume,
+        offerBonusAmount
+      } = userData;
       
       // Check if email already exists
       const existingUser = await User.findOne({ email: email.toLowerCase() });
       if (existingUser) {
         throw new Error('Email already in use');
+      }
+
+      if (resume && userType && userType !== 'candidate') {
+        throw new AuthorizationError('Only candidates can upload a resume');
       }
       
       // Create new user

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -28,6 +28,9 @@ class UserService {
 
   async updateProfile(userId, updates) {
     const user = await this.getUserById(userId);
+    if (updates.resume !== undefined && user.userType !== 'candidate') {
+      throw new AuthorizationError('Only candidates can upload a resume');
+    }
     const fields = ['firstName', 'lastName', 'phoneNumber', 'profileImage', 'resume', 'offerBonusAmount'];
     fields.forEach(f => {
       if (updates[f] !== undefined) user[f] = updates[f];

--- a/frontend/src/components/auth/registerForm.jsx
+++ b/frontend/src/components/auth/registerForm.jsx
@@ -20,7 +20,7 @@ const RegisterForm = () => {
       email: '',
       password: '',
       confirmPassword: '',
-      userType: 'candidate', // Default user type
+      userType: '',
       resume: null,
       offerBonusAmount: ''
     },
@@ -58,6 +58,10 @@ const RegisterForm = () => {
       errors.confirmPassword = 'Passwords do not match';
     }
  
+    if (!values.userType) {
+      errors.userType = 'Please select a user type';
+    }
+
     if (values.resume && values.resume.type && !["application/pdf","application/msword","application/vnd.openxmlformats-officedocument.wordprocessingml.document"].some(t => values.resume.type.includes(t))) {
       errors.resume = 'Resume must be a PDF or Word document';
     }
@@ -184,13 +188,6 @@ const RegisterForm = () => {
           required
         />
 
-        <FileInput
-          label="Upload Resume (PDF or Word doc)"
-          name="resume"
-          accept="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-          onChange={handleChange}
-          error={errors.resume}
-        />
 
         {values.userType === 'candidate' && (
           <Input
@@ -203,7 +200,7 @@ const RegisterForm = () => {
             placeholder="50"
           />
         )}
-        
+
         <div className="mt-4">
           <label className="block text-sm font-medium text-gray-700 mb-1">
             I am registering as:
@@ -234,7 +231,17 @@ const RegisterForm = () => {
             </label>
           </div>
         </div>
-        
+
+        {values.userType === 'candidate' && (
+          <FileInput
+            label="Upload Resume (PDF or Word doc)"
+            name="resume"
+            accept="application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            onChange={handleChange}
+            error={errors.resume}
+          />
+        )}
+
         <div className="mt-4 text-sm text-gray-600">
           By creating an account, you agree to our{' '}
           <Link to="/terms" className="text-blue-600 hover:text-blue-500">

--- a/tests/resumePermissions.test.js
+++ b/tests/resumePermissions.test.js
@@ -1,0 +1,43 @@
+const { describe, it, expect, vi } = require('./test-helpers');
+const { AuthorizationError } = require('../backend/utils/errorTypes');
+
+// Mocks for AuthService.register
+const savedUsers = [];
+class User {
+  constructor(data) { Object.assign(this, data); }
+  save = vi.fn(async () => { savedUsers.push(this); return this; });
+  static async findOne() { return null; }
+}
+vi.mock('../backend/models/user', () => User);
+vi.mock('../backend/services/emailService', () => ({ sendEmail: vi.fn() }));
+vi.mock('../backend/services/googleService', () => ({ verifyIdToken: vi.fn(), getAvailability: vi.fn() }));
+vi.mock('../backend/utils/logger', () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() }));
+vi.mock('bcryptjs', () => ({ genSalt: vi.fn(), hash: vi.fn(), compare: vi.fn() }));
+vi.mock('crypto', () => ({ randomBytes: () => Buffer.from('rand') }));
+vi.mock('jsonwebtoken', () => ({ sign: () => 'token', verify: () => ({}) }));
+
+const AuthService = require('../backend/services/authService');
+const UserService = require('../backend/services/userService');
+
+describe('resume permissions', () => {
+  it('disallows resume upload for non-candidates during registration', async () => {
+    await expect(
+      AuthService.register({
+        email: 'pro@test.com',
+        password: 'Password1',
+        firstName: 'Pro',
+        lastName: 'User',
+        userType: 'professional',
+        resume: 'filedata'
+      })
+    ).rejects.toThrow('Only candidates can upload a resume');
+  });
+
+  it('disallows resume update for non-candidates', async () => {
+    const user = { _id: '1', userType: 'professional', save: vi.fn() };
+    vi.spyOn(UserService, 'getUserById').mockResolvedValue(user);
+    await expect(
+      UserService.updateProfile('1', { resume: 'data' })
+    ).rejects.toThrow('Only candidates can upload a resume');
+  });
+});


### PR DESCRIPTION
## Summary
- include resume in registration controller
- block resume uploads in registration service for non-candidates
- block resume updates in user service for non-candidates
- test that only candidates may upload resumes
- only show resume input after candidate type selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a3e8b07548325950fdd5bd5c3749f