### PR TITLE
Use explicit frontend port

### DIFF
--- a/.env
+++ b/.env
@@ -6,7 +6,7 @@ NODE_ENV=development
 PORT=5000
 # Host port for the API container
 API_PORT=8000
-FRONTEND_URL=http://localhost:3001
+FRONTEND_URL=http://localhost:3000
 # Set to true to disable real external integrations
 MOCK_INTEGRATIONS=true
 
@@ -57,7 +57,7 @@ COOLDOWN_DAYS=7
 REFERRAL_PLATFORM_FEE_PERCENT=15
 
 # React App
-REACT_APP_API_URL=/api
+REACT_APP_API_URL=http://localhost:8000/api
 
 # Compliance & Observability
 LOG_ARCHIVE_BUCKET=mentor-connect-logs

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ access to specific roles (e.g. `candidate`, `professional`, `admin`).
       ```bash
       docker compose up --build
       ```
-   3. The frontend will be available at `http://localhost:3000` and the API at `http://localhost:${API_PORT:-5000}`.
+   3. Open `http://localhost:3000` in your browser. The React app will talk to the API at `http://localhost:${API_PORT:-8000}`.
    4. When you're done, stop the stack:
       ```bash
       docker compose down

--- a/backend/app.js
+++ b/backend/app.js
@@ -49,7 +49,7 @@ app.use(errorHandler);
 // Set up Socket.io
 const io = socketIo(server, {
   cors: {
-    origin: config.app.env === 'production' ? false : ['http://localhost:3001'],
+    origin: config.app.env === 'production' ? false : [config.app.frontendUrl],
     methods: ['GET', 'POST'],
     credentials: true
   }

--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -14,7 +14,7 @@ const config = {
     return {
       env: process.env.NODE_ENV || 'development',
       port: parseInt(process.env.PORT, 10) || 5000,
-      frontendUrl: process.env.FRONTEND_URL || 'http://localhost:3001',
+      frontendUrl: process.env.FRONTEND_URL || 'http://localhost:3000',
       apiUrl: process.env.API_URL,
       mockIntegrations: process.env.MOCK_INTEGRATIONS === 'true'
     };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,9 +69,6 @@ services:
     build:
       context: .
       dockerfile: frontend/Dockerfile
-      args:
-        - REACT_APP_API_URL=/api  # Changed from ${REACT_APP_API_URL}
-        - REACT_APP_STRIPE_PUBLIC_KEY=${REACT_APP_STRIPE_PUBLIC_KEY}
     restart: always
     ports:
       - "3000:3000"
@@ -80,7 +77,9 @@ services:
     networks:
       - app-network
     environment:
-    - REACT_APP_DOCKER=true
+      - REACT_APP_API_URL=${REACT_APP_API_URL}
+      - REACT_APP_STRIPE_PUBLIC_KEY=${REACT_APP_STRIPE_PUBLIC_KEY}
+      - REACT_APP_DOCKER=false
 
   nginx:
     image: nginx:alpine

--- a/frontend/src/config/index.jsx
+++ b/frontend/src/config/index.jsx
@@ -30,8 +30,8 @@ function getEnv(name) {
  */
 function loadConfig() {
   // Check if running in Docker by looking for common Docker environment variables
-  const isDocker = process.env.REACT_APP_DOCKER === 'true' || 
-                   window.location.hostname === 'localhost' && window.location.port === '80';
+  const isDocker = process.env.REACT_APP_DOCKER === 'true' ||
+                   (window.location.hostname === 'localhost' && (!window.location.port || window.location.port === '80'));
   
   const config = {
     apiUrl: getEnv('REACT_APP_API_URL') || (isDocker ? '/api' : 'http://localhost:8000/api'),


### PR DESCRIPTION
## Summary
- set default FRONTEND_URL to http://localhost:3000
- expose frontend API url at http://localhost:8000/api
- pass runtime env vars to the frontend container
- document opening the app at `http://localhost:3000`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a44504c6883258ad75c0f347efa60