### PR TITLE
Fix nginx startup error

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -28,7 +28,7 @@ server {
     }
     
     location @fallback {
-        proxy_pass http://frontend:3000/;
+        proxy_pass http://frontend:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- remove trailing slash from proxy_pass in named location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a716545788325bf5594d0023411d8