### PR TITLE
Fix import paths to match lowercase filenames

### DIFF
--- a/frontend/src/app.jsx
+++ b/frontend/src/app.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { AuthProvider } from './contexts/AuthContext';
-import { NotificationProvider } from './contexts/NotificationContext';
+import { AuthProvider } from './contexts/authContext';
+import { NotificationProvider } from './contexts/notificationContext';
 import AppRoutes from './routes';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';

--- a/frontend/src/components/admin/adminHeader.jsx
+++ b/frontend/src/components/admin/adminHeader.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useAuth } from '../../hooks';
 import { useNavigate } from 'react-router-dom';
-import Button from '../common/Button';
+import Button from '../common/button';
 
 const AdminHeader = () => {
   const { user, logout } = useAuth();

--- a/frontend/src/components/admin/adminLayout.jsx
+++ b/frontend/src/components/admin/adminLayout.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Outlet, Navigate } from 'react-router-dom';
 import { useAuth } from '../../hooks';
-import AdminSidebar from './AdminSidebar';
-import AdminHeader from './AdminHeader';
+import AdminSidebar from './adminSidebar';
+import AdminHeader from './adminHeader';
 
 const AdminLayout = () => {
   const { user, loading } = useAuth();

--- a/frontend/src/components/auth/forgotPasswordForm.jsx
+++ b/frontend/src/components/auth/forgotPasswordForm.jsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useForm } from '../../hooks';
 import AuthAPI from '../../api/auth';
-import Input from '../../common/Input';
-import Button from '../../common/Button';
+import Input from '../../common/input';
+import Button from '../../common/button';
 
 const ForgotPasswordForm = () => {
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/components/auth/index.js
+++ b/frontend/src/components/auth/index.js
@@ -1,3 +1,3 @@
-export { default as LoginForm } from './LoginForm';
-export { default as RegisterForm } from './RegisterForm';
-export { default as ForgotPasswordForm } from './ForgotPasswordForm';
+export { default as LoginForm } from './loginForm';
+export { default as RegisterForm } from './registerForm';
+export { default as ForgotPasswordForm } from './forgotPasswordForm';

--- a/frontend/src/components/auth/loginForm.jsx
+++ b/frontend/src/components/auth/loginForm.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth, useForm } from '../../hooks';
-import Input from '../../common/Input';
-import Button from '../../common/Button';
+import Input from '../../common/input';
+import Button from '../../common/button';
 
 const LoginForm = () => {
   const navigate = useNavigate();

--- a/frontend/src/components/auth/registerForm.jsx
+++ b/frontend/src/components/auth/registerForm.jsx
@@ -2,9 +2,9 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from '../../hooks';
 import AuthAPI from '../../api/auth';
-import Input from '../../common/Input';
-import FileInput from '../../common/FileInput';
-import Button from '../../common/Button';
+import Input from '../../common/input';
+import FileInput from '../../common/fileInput';
+import Button from '../../common/button';
 
 const RegisterForm = () => {
   const navigate = useNavigate();

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -1,8 +1,8 @@
-export { default as Button } from './Button';
-export { default as Card } from './Card';
-export { default as Input } from './Input';
-export { default as FileInput } from './FileInput';
-export { default as Modal } from './Modal';
-export { default as Navbar } from './Navbar';
-export { default as Footer } from './Footer';
-export { default as Spinner } from './Spinner';
+export { default as Button } from './button';
+export { default as Card } from './card';
+export { default as Input } from './input';
+export { default as FileInput } from './fileInput';
+export { default as Modal } from './modal';
+export { default as Navbar } from './navbar';
+export { default as Footer } from './footer';
+export { default as Spinner } from './spinner';

--- a/frontend/src/components/common/modal.jsx
+++ b/frontend/src/components/common/modal.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import Button from './Button';
+import Button from './button';
 
 const Modal = ({ 
   isOpen, 

--- a/frontend/src/components/common/navbar.jsx
+++ b/frontend/src/components/common/navbar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth, useNotifications } from '../../hooks';
-import Button from './Button';
+import Button from './button';
 
 const Navbar = () => {
   const { user, logout } = useAuth();

--- a/frontend/src/components/professionals/index.js
+++ b/frontend/src/components/professionals/index.js
@@ -1,4 +1,4 @@
-export { default as ProfessionalCard } from './ProfessionalCard';
-export { default as ProfessionalList } from './ProfessionalList';
-export { default as ProfessionalFilter } from './ProfessionalFilter';
-export { default as ProfessionalDetail } from './ProfessionalDetail';
+export { default as ProfessionalCard } from './professionalCard';
+export { default as ProfessionalList } from './professionalList';
+export { default as ProfessionalFilter } from './professionalFilter';
+export { default as ProfessionalDetail } from './professionalDetail';

--- a/frontend/src/components/professionals/professionalCard.jsx
+++ b/frontend/src/components/professionals/professionalCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import Button from '../../common/Button';
+import Button from '../../common/button';
 
 const ProfessionalCard = ({ professional }) => {
   // Format hourly rate as currency

--- a/frontend/src/components/professionals/professionalDetail.jsx
+++ b/frontend/src/components/professionals/professionalDetail.jsx
@@ -3,10 +3,10 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../hooks';
 import ProfessionalsAPI from '../../api/professionals';
 import SessionsAPI from '../../api/sessions';
-import Button from '../common/Button';
-import Card from '../common/Card';
-import Spinner from '../common/Spinner';
-import BookingForm from '../sessions/BookingForm';
+import Button from '../common/button';
+import Card from '../common/card';
+import Spinner from '../common/spinner';
+import BookingForm from '../sessions/bookingForm';
 
 const ProfessionalDetail = () => {
   const { id } = useParams();

--- a/frontend/src/components/professionals/professionalFilter.jsx
+++ b/frontend/src/components/professionals/professionalFilter.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ProfessionalsAPI from '../../api/professionals';
-import Input from '../common/Input';
-import Button from '../common/Button';
+import Input from '../common/input';
+import Button from '../common/button';
 
 const ProfessionalFilter = ({ onFilterChange }) => {
   const [industries, setIndustries] = useState([]);

--- a/frontend/src/components/professionals/professionalList.jsx
+++ b/frontend/src/components/professionals/professionalList.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import ProfessionalsAPI from '../../api/professionals';
-import ProfessionalCard from './ProfessionalCard';
-import ProfessionalFilter from './ProfessionalFilter';
-import Spinner from '../common/Spinner';
-import Button from '../common/Button';
+import ProfessionalCard from './professionalCard';
+import ProfessionalFilter from './professionalFilter';
+import Spinner from '../common/spinner';
+import Button from '../common/button';
 
 const ProfessionalList = () => {
   const [professionals, setProfessionals] = useState([]);

--- a/frontend/src/components/referrals/index.js
+++ b/frontend/src/components/referrals/index.js
@@ -1,3 +1,3 @@
-export { default as ReferralInstructions } from './ReferralInstructions';
-export { default as ReferralList } from './ReferralList';
-export { default as ReferralHistory } from './ReferralHistory';
+export { default as ReferralInstructions } from './referralInstructions';
+export { default as ReferralList } from './referralList';
+export { default as ReferralHistory } from './referralHistory';

--- a/frontend/src/components/referrals/referralHistory.jsx
+++ b/frontend/src/components/referrals/referralHistory.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ReferralsAPI from '../../api/referrals';
-import Card from '../common/Card';
-import Spinner from '../common/Spinner';
+import Card from '../common/card';
+import Spinner from '../common/spinner';
 
 const ReferralHistory = () => {
   const [referrals, setReferrals] = useState([]);

--- a/frontend/src/components/referrals/referralInstructions.jsx
+++ b/frontend/src/components/referrals/referralInstructions.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Card from '../common/Card';
+import Card from '../common/card';
 
 const ReferralInstructions = () => {
   return (

--- a/frontend/src/components/referrals/referralList.jsx
+++ b/frontend/src/components/referrals/referralList.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import ReferralsAPI from '../../api/referrals';
-import Card from '../common/Card';
-import Spinner from '../common/Spinner';
-import Button from '../common/Button';
-import ReferralInstructions from './ReferralInstructions';
+import Card from '../common/card';
+import Spinner from '../common/spinner';
+import Button from '../common/button';
+import ReferralInstructions from './referralInstructions';
 
 const ReferralList = () => {
   const [referrals, setReferrals] = useState([]);

--- a/frontend/src/components/sessions/index.js
+++ b/frontend/src/components/sessions/index.js
@@ -1,7 +1,7 @@
-export { default as BookingForm } from "./BookingForm";
-export { default as SessionDetail } from "./SessionDetail";
-export { default as SessionCard } from "./SessionCard";
-export { default as SessionList } from "./SessionList";
-export { default as SessionCalendar } from "./SessionCalendar";
+export { default as BookingForm } from "./bookingForm";
+export { default as SessionDetail } from "./sessionDetail";
+export { default as SessionCard } from "./sessionCard";
+export { default as SessionList } from "./sessionList";
+export { default as SessionCalendar } from "./sessionCalendar";
 export { default as RescheduleModal } from "./rescheduleModal";
 export { default as ProfileStrip } from "./profileStrip";

--- a/frontend/src/components/sessions/profileStrip.jsx
+++ b/frontend/src/components/sessions/profileStrip.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import Modal from "../common/Modal";
+import Modal from "../common/modal";
 
 const ProfileStrip = ({ user, role }) => {
   const [open, setOpen] = useState(false);

--- a/frontend/src/components/sessions/rescheduleModal.jsx
+++ b/frontend/src/components/sessions/rescheduleModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import Modal from "../common/Modal";
-import Button from "../common/Button";
+import Modal from "../common/modal";
+import Button from "../common/button";
 import SessionsAPI from "../../api/sessions";
 
 const RescheduleModal = ({ isOpen, onClose, session, onRescheduled }) => {

--- a/frontend/src/components/sessions/sessionCard.jsx
+++ b/frontend/src/components/sessions/sessionCard.jsx
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import SessionsAPI from "../../api/sessions";
-import Button from "../common/Button";
-import Modal from "../common/Modal";
+import Button from "../common/button";
+import Modal from "../common/modal";
 import RescheduleModal from "./rescheduleModal";
 import ProfileStrip from "./profileStrip";
 

--- a/frontend/src/components/sessions/sessionDetail.jsx
+++ b/frontend/src/components/sessions/sessionDetail.jsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from "react";
 import { useParams, Link } from "react-router-dom";
 import { useAuth } from "../../hooks";
 import SessionsAPI from "../../api/sessions";
-import Card from "../common/Card";
-import Button from "../common/Button";
-import Spinner from "../common/Spinner";
+import Card from "../common/card";
+import Button from "../common/button";
+import Spinner from "../common/spinner";
 import FeedbackForm from './feedbackForm';
 import JobOfferForm from '../jobOffers/jobOfferForm';
 

--- a/frontend/src/components/sessions/sessionList.jsx
+++ b/frontend/src/components/sessions/sessionList.jsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import SessionsAPI from '../../api/sessions';
-import SessionCard from './SessionCard';
-import Spinner from '../common/Spinner';
-import Button from '../common/Button';
+import SessionCard from './sessionCard';
+import Spinner from '../common/spinner';
+import Button from '../common/button';
 
 const SessionList = ({ type = 'user' }) => {
   const [sessions, setSessions] = useState([]);

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/authContext';
 
 export const useAuth = () => {
   return useContext(AuthContext);

--- a/frontend/src/hooks/useNotifications.js
+++ b/frontend/src/hooks/useNotifications.js
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { NotificationContext } from '../contexts/NotificationContext';
+import { NotificationContext } from '../contexts/notificationContext';
 
 export const useNotifications = () => {
   return useContext(NotificationContext);

--- a/frontend/src/layouts/dashboardLayout.jsx
+++ b/frontend/src/layouts/dashboardLayout.jsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { Outlet, Link, useLocation, Navigate } from 'react-router-dom';
 import { useAuth } from '../hooks';
-import Navbar from '../components/common/Navbar';
-import Footer from '../components/common/Footer';
+import Navbar from '../components/common/navbar';
+import Footer from '../components/common/footer';
 
 const DashboardLayout = () => {
   const { user, loading } = useAuth();

--- a/frontend/src/layouts/mainLayout.jsx
+++ b/frontend/src/layouts/mainLayout.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import Navbar from '../components/common/Navbar';
-import Footer from '../components/common/Footer';
+import Navbar from '../components/common/navbar';
+import Footer from '../components/common/footer';
 
 const MainLayout = () => {
   return (

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Button from '../components/common/Button';
+import Button from '../components/common/button';
 
 const Home = () => {
   return (

--- a/frontend/src/pages/admin/adminDashboard.jsx
+++ b/frontend/src/pages/admin/adminDashboard.jsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../hooks';
 import { Navigate } from 'react-router-dom';
 import AdminAPI from '../../api/admin';
-import Card from '../../components/common/Card';
-import Button from '../../components/common/Button';
-import Spinner from '../../components/common/Spinner';
+import Card from '../../components/common/card';
+import Button from '../../components/common/button';
+import Spinner from '../../components/common/spinner';
 
 const AdminDashboard = () => {
   const { user } = useAuth();

--- a/frontend/src/pages/admin/analytics.jsx
+++ b/frontend/src/pages/admin/analytics.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import AdminAPI from '../../api/admin';
-import Card from '../../components/common/Card';
-import StatsCard from '../../components/admin/StatsCard';
-import Spinner from '../../components/common/Spinner';
+import Card from '../../components/common/card';
+import StatsCard from '../../components/admin/statsCard';
+import Spinner from '../../components/common/spinner';
 
 const Analytics = () => {
   const [analytics, setAnalytics] = useState(null);

--- a/frontend/src/pages/admin/referralManagement.jsx
+++ b/frontend/src/pages/admin/referralManagement.jsx
@@ -1,9 +1,9 @@
 
 import React, { useState, useEffect } from 'react';
 import AdminAPI from '../../api/admin';
-import Card from '../../components/common/Card';
-import Button from '../../components/common/Button';
-import Spinner from '../../components/common/Spinner';
+import Card from '../../components/common/card';
+import Button from '../../components/common/button';
+import Spinner from '../../components/common/spinner';
 
 const ReferralManagement = () => {
   const [referrals, setReferrals] = useState([]);

--- a/frontend/src/pages/admin/sessionManagement.jsx
+++ b/frontend/src/pages/admin/sessionManagement.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import AdminAPI from '../../api/admin';
-import Card from '../../components/common/Card';
-import Button from '../../components/common/Button';
-import Spinner from '../../components/common/Spinner';
+import Card from '../../components/common/card';
+import Button from '../../components/common/button';
+import Spinner from '../../components/common/spinner';
 
 const SessionManagement = () => {
   const [sessions, setSessions] = useState([]);

--- a/frontend/src/pages/admin/userManagement.jsx
+++ b/frontend/src/pages/admin/userManagement.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import AdminAPI from '../../api/admin';
-import Card from '../../components/common/Card';
-import Button from '../../components/common/Button';
-import Spinner from '../../components/common/Spinner';
+import Card from '../../components/common/card';
+import Button from '../../components/common/button';
+import Spinner from '../../components/common/spinner';
 
 const UserManagement = () => {
   const [users, setUsers] = useState([]);

--- a/frontend/src/pages/professionalDetails.jsx
+++ b/frontend/src/pages/professionalDetails.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProfessionalDetail from '../components/professionals/ProfessionalDetail';
+import ProfessionalDetail from '../components/professionals/professionalDetail';
 
 const ProfessionalDetailPage = () => {
   return <ProfessionalDetail />;

--- a/frontend/src/pages/professionalsPage.jsx
+++ b/frontend/src/pages/professionalsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProfessionalList from '../components/professionals/ProfessionalList';
+import ProfessionalList from '../components/professionals/professionalList';
 
 const ProfessionalsPage = () => {
   return (

--- a/frontend/src/pages/sessionDetailPage.jsx
+++ b/frontend/src/pages/sessionDetailPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SessionDetail from '../components/sessions/SessionDetail';
+import SessionDetail from '../components/sessions/sessionDetail';
 
 const SessionDetailPage = () => {
   return <SessionDetail />;

--- a/frontend/src/pages/sessionsPage.jsx
+++ b/frontend/src/pages/sessionsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../hooks';
-import SessionList from '../components/sessions/SessionList';
-import Card from '../components/common/Card';
+import SessionList from '../components/sessions/sessionList';
+import Card from '../components/common/card';
 
 const SessionsPage = () => {
   const { user } = useAuth();

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -5,7 +5,7 @@ import { useAuth } from './hooks';
 
 
 // Admin Components
-import AdminLayout from './components/admin/AdminLayout';
+import AdminLayout from './components/admin/adminLayout';
 import AdminDashboard from './pages/admin/adminDashboard';
 import SessionManagement from './pages/admin/sessionManagement';
 import ReferralManagement from './pages/admin/referralManagement';
@@ -13,25 +13,25 @@ import UserManagement from './pages/admin/userManagement';
 import Analytics from './pages/admin/analytics';
 
 // Layouts
-import MainLayout from './layouts/MainLayout';
-import AuthLayout from './layouts/AuthLayout';
-import DashboardLayout from './layouts/DashboardLayout';
+import MainLayout from './layouts/mainLayout';
+import AuthLayout from './layouts/authLayout';
+import DashboardLayout from './layouts/dashboardLayout';
 
 // Public pages
 import Home from './pages/Home';
-import ProfessionalsPage from './pages/ProfessionalsPage';
-import ProfessionalDetailPage from './pages/ProfessionalDetailsPage';
+import ProfessionalsPage from './pages/professionalsPage';
+import ProfessionalDetailPage from './pages/professionalDetails';
 
 // Auth pages
-import Login from './pages/auth/Login';
-import Register from './pages/auth/Register';
-import ForgotPassword from './pages/auth/ForgotPassword';
-import ResetPassword from './pages/auth/ResetPassword';
-import VerifyEmail from './pages/auth/VerifyEmail';
+import Login from './pages/auth/login';
+import Register from './pages/auth/register';
+import ForgotPassword from './pages/auth/forgotPassword';
+import ResetPassword from './pages/auth/resetPassword';
+import VerifyEmail from './pages/auth/verifyEmail';
 
 // Protected pages
-import SessionsPage from './pages/SessionsPage';
-import SessionDetailPage from './pages/SessionDetailPage';
+import SessionsPage from './pages/sessionsPage';
+import SessionDetailPage from './pages/sessionDetailPage';
 import ReferralHistoryPage from './pages/ReferralHistory';
 import ProfilePage from './pages/ProfilePage';
 import SettingsPage from './pages/SettingsPage';


### PR DESCRIPTION
## Summary
- update React imports to lowercase paths across components, pages and layouts
- adjust hooks and routes to use lowercase file names

## Testing
- `npm test`
- `npm run lint` *(fails: 2 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683b4d0d0ea0832589c529ca1dff7222